### PR TITLE
Allow Svelte syntax highlighting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -221,7 +221,7 @@ vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { de
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'typescript', 'help' },
+  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'svelte', 'typescript', 'help' },
 
   highlight = { enable = true },
   indent = { enable = true, disable = { 'python' } },


### PR DESCRIPTION
I needed Svelte syntax highlighting, and I wouldn't figure out how to enable it without adapting init.lua. If there's a way to enable it from my `after/plugins/defaults.lua` or `lua/custom/plugins.lua` folder, I'm happy to close the PR and alter my local setup instead.